### PR TITLE
ENH: stats.lognormal.fit: handle cases where `dL_dLoc(np.min(data)-eps) > 0`

### DIFF
--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -5519,6 +5519,10 @@ class lognorm_gen(rv_continuous):
         https://doi.org/10.2307/2287466
         \n\n""")
     def fit(self, data, *args, **kwds):
+
+        if kwds.pop('superfit', False):
+            return super().fit(data, *args, **kwds)
+
         parameters = _check_fit_input_parameters(self, data, args, kwds)
         data, fshape, floc, fscale = parameters
 
@@ -5536,6 +5540,13 @@ class lognorm_gen(rv_continuous):
 
         if floc is None:
             rbrack = np.nextafter(min(data), -np.inf)
+
+            i = 1
+            delta = np.min(data) - rbrack
+            while dL_dLoc(rbrack) >= -1e-6:
+                i *= 2
+                rbrack = np.min(data) - delta*i
+
             lbrack = rbrack - 1
             i = 0
 
@@ -5553,6 +5564,9 @@ class lognorm_gen(rv_continuous):
             if floc >= np.min(data):
                 raise FitDataError("lognorm", lower=0., upper=np.inf)
             loc = floc
+
+        if rbrack < -1e6:
+            loc = np.nextafter(min(data), -np.inf)
 
         shape, scale = get_shape_scale(loc)
         if not (self._argcheck(shape) and scale > 0):

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -1597,8 +1597,8 @@ class TestPareto:
                              [p for p in product([True, False], repeat=3)
                               if False in p])
     @np.errstate(invalid="ignore")
-    def test_fit_MLE_comp_optimizer(self, rvs_shape, rvs_loc, rvs_scale,
-                                    fix_shape, fix_loc, fix_scale, rng):
+    def test_fit_MLE_comp_optimzer(self, rvs_shape, rvs_loc, rvs_scale,
+                                   fix_shape, fix_loc, fix_scale, rng):
         data = stats.pareto.rvs(size=100, b=rvs_shape, scale=rvs_scale,
                                 loc=rvs_loc, random_state=rng)
         args = [data, (stats.pareto._fitstart(data), )]
@@ -2170,7 +2170,7 @@ class TestInvgauss:
 
     @pytest.mark.parametrize("rvs_mu,rvs_loc,rvs_scale",
                              [(2, 0, 1), (np.random.rand(3)*10)])
-    def test_fit_MLE_comp_optimizer(self, rvs_mu, rvs_loc, rvs_scale):
+    def test_fit_MLE_comp_optimzer(self, rvs_mu, rvs_loc, rvs_scale):
         data = stats.invgauss.rvs(size=100, mu=rvs_mu,
                                   loc=rvs_loc, scale=rvs_scale)
 
@@ -2317,7 +2317,7 @@ class TestLaplace:
     @pytest.mark.parametrize("rvs_scale,rvs_loc", [(10, -5),
                                                    (5, 10),
                                                    (.2, .5)])
-    def test_fit_MLE_comp_optimizer(self, rvs_loc, rvs_scale):
+    def test_fit_MLE_comp_optimzer(self, rvs_loc, rvs_scale):
         data = stats.laplace.rvs(size=1000, loc=rvs_loc, scale=rvs_scale)
 
         # the log-likelihood function for laplace is given by
@@ -3093,8 +3093,9 @@ class TestLognorm:
     @pytest.mark.parametrize('fix_shape, fix_loc, fix_scale',
                              [e for e in product((False, True), repeat=3)
                               if False in e])
-    def test_fit_MLE_comp_optimizer(self, rvs_shape, rvs_loc, rvs_scale,
-                                    fix_shape, fix_loc, fix_scale, rng):
+    @np.errstate(invalid="ignore")
+    def test_fit_MLE_comp_optimzer(self, rvs_shape, rvs_loc, rvs_scale,
+                                   fix_shape, fix_loc, fix_scale, rng):
         data = stats.lognorm.rvs(size=100, s=rvs_shape, scale=rvs_scale,
                                  loc=rvs_loc, random_state=rng)
         args = [data, (stats.lognorm._fitstart(data), )]


### PR DESCRIPTION
There is probably some useful stuff that gets reverted here, but I wanted to go back to [3bcfcc5](https://github.com/scipy/scipy/pull/16839/commits/3bcfcc5c515fee2134913545fad90c9dd6725f82) because I reviewed that carefully, and I don't think the commits since then have made things much more robust. That's all the first commit does. 

The second commit is what I'm talking about in https://github.com/scipy/scipy/pull/16839#issuecomment-1221474397. 

I'd suggest merging this, then we can move forward again from here.